### PR TITLE
スクロール位置のオフセット問題を修正

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,18 @@ export default function Header() {
     } else {
       const element = document.getElementById(sectionId);
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth' });
+        // ヘッダーの高さを取得
+        const header = document.querySelector('header');
+        const headerHeight = header ? header.offsetHeight : 0;
+        
+        // 要素の位置を取得してヘッダーの高さ分を引く
+        const elementPosition = element.getBoundingClientRect().top + window.pageYOffset;
+        const offsetPosition = elementPosition - headerHeight;
+        
+        window.scrollTo({
+          top: offsetPosition,
+          behavior: 'smooth'
+        });
         window.history.pushState(null, '', `#${sectionId}`);
       }
     }


### PR DESCRIPTION
## 概要
- ナビゲーションリンクをクリックした際に、想定位置より下にスクロールする問題を修正
- スティッキーヘッダーの高さを考慮したスクロール位置計算を実装

## 変更内容
- `Header.tsx`の`scrollToSection`関数を修正
  - `scrollIntoView`の代わりに手動でスクロール位置を計算
  - ヘッダーの高さ（offsetHeight）を取得し、スクロール位置から減算
  - `window.scrollTo`で正確な位置へスムーズスクロール

## テスト内容
- [x] #home へのナビゲーション（ページトップへ）
- [x] #about へのナビゲーション
- [x] #projects へのナビゲーション
- [x] #publications へのナビゲーション
- [x] #contact へのナビゲーション
- [x] モバイルメニューからのナビゲーション